### PR TITLE
Proper artifact handling on release tag building.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,48 +11,26 @@ jobs:
     release:
         runs-on: ubuntu-latest
         needs: build
+        permissions:
+          contents: write
         if: startsWith(github.ref, 'refs/tags/')
         steps:
             - name: checkout repo
               uses: actions/checkout@v4
 
+            - name: pull artifacts from previous build step
+              uses: actions/download-artifact@v4
+              with:
+                path: release-pdfs
+                merge-multiple: True
+
+            - name: list artifacts
+              id: ls_release_pdfs
+              run: ls -l release-pdfs/*.pdf
+
             - name: Create Release
               id: create_release
-              uses: actions/create-release@v1
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              uses: softprops/action-gh-release@v2
               with:
-                tag_name: ${{ github.ref }}
-                release_name: Release ${{ github.ref }}
-                draft: false
-                prerelease: false
-
-            - name: Upload Release Asset slide-N
-              uses: actions/upload-release-asset@v1
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                upload_url: ${{ steps.create_release.outputs.upload_url }}
-                asset_path: tex/slide-N.pdf
-                asset_name: slide-N.pdf
-                asset_content_type: application/pdf
-
-            - name: Upload Release Asset slide-E
-              uses: actions/upload-release-asset@v1
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                upload_url: ${{ steps.create_release.outputs.upload_url }}
-                asset_path: tex/slide-E.pdf
-                asset_name: slide-E.pdf
-                asset_content_type: application/pdf
-
-            - name: Upload Release Asset slide-NE
-              uses: actions/upload-release-asset@v1
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                upload_url: ${{ steps.create_release.outputs.upload_url }}
-                asset_path: tex/slide-NE.pdf
-                asset_name: slide-NE.pdf
-                asset_content_type: application/pdf
+                files: |
+                  release-pdfs/*.pdf

--- a/release-pdfs/.keep
+++ b/release-pdfs/.keep
@@ -1,0 +1,4 @@
+This directory is used by the release pipeline.
+
+Not sure it hurts when it doesn't pre-exist.
+But it doesn't hurt if it does pre-exist.


### PR DESCRIPTION
Artifacts from a previous build step are not automatically available, but need to be pulled back into the workspace. This code does that.

The previously used `actions/create-release` is no longer maintained and generates deprecation warnings in the log. On that action's [description](https://github.com/actions/create-release), one of several maintained alternatives is `softprops/action-gh-release`. So this was used instead.

To be able to create a release, the job needs write-access to the repository (aka `contents`). This could be configured globally, but in this repo, it isn't. The (better) alternative is to [configure write-access on a job basis](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token). That is done here.

I tested this, it has [worked for me](https://github.com/aknrdureegaesr/50ohm-pdf-slides/actions/runs/11450273151).